### PR TITLE
fix: correct plugin settings registration name and add save button

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,7 +66,7 @@ registerRoute({
 });
 
 // Register plugin settings
-registerPluginSettings('polaris', PolarisSettings);
+registerPluginSettings('headlamp-polaris-plugin', PolarisSettings, true);
 
 // Register details view section for supported controller types
 registerDetailsViewSection(({ resource }) => {


### PR DESCRIPTION
## Summary
- Fix plugin settings not showing by correcting registration name
- Changed from `'polaris'` to `'headlamp-polaris-plugin'` (matches package.json)
- Added `displaySaveButton=true` parameter

## Root Cause
The plugin name passed to `registerPluginSettings()` must match the plugin name from `package.json`. We were using `'polaris'` but the actual plugin name is `'headlamp-polaris-plugin'`.

## Changes
```typescript
// Before
registerPluginSettings('polaris', PolarisSettings);

// After
registerPluginSettings('headlamp-polaris-plugin', PolarisSettings, true);
```

## API Signature
According to Headlamp plugin API:
```typescript
registerPluginSettings(name: string, component: PluginSettingsComponentType, displaySaveButton?: boolean): void
```

## Test Plan
- ✅ All tests passing (50/50)
- ✅ TypeScript compilation clean
- ✅ Build successful
- 🎯 Settings page should now display with save button

🤖 Generated with [Claude Code](https://claude.com/claude-code)