### PR TITLE
fix: use correct CSS variables for drawer dark mode support

### DIFF
--- a/src/components/NamespacesListView.tsx
+++ b/src/components/NamespacesListView.tsx
@@ -103,7 +103,8 @@ function NamespaceDetailPanel({ namespace, onClose }: NamespaceDetailPanelProps)
         top: 0,
         bottom: 0,
         width: '1000px',
-        backgroundColor: 'var(--mui-palette-background-paper, var(--background-paper, #fff))',
+        backgroundColor: 'var(--mui-palette-background-default)',
+        color: 'var(--mui-palette-text-primary)',
         boxShadow: '-2px 0 8px rgba(0,0,0,0.15)',
         overflowY: 'auto',
         zIndex: 1200,
@@ -118,9 +119,7 @@ function NamespaceDetailPanel({ namespace, onClose }: NamespaceDetailPanelProps)
           alignItems: 'center',
         }}
       >
-        <h2
-          style={{ margin: 0, color: 'var(--mui-palette-text-primary, var(--text-primary, #000))' }}
-        >
+        <h2 style={{ margin: 0, color: 'var(--mui-palette-text-primary)' }}>
           Polaris — {namespace}
         </h2>
         <button
@@ -131,7 +130,7 @@ function NamespaceDetailPanel({ namespace, onClose }: NamespaceDetailPanelProps)
             fontSize: '24px',
             cursor: 'pointer',
             padding: '0 8px',
-            color: 'var(--mui-palette-text-primary, var(--text-primary, #000))',
+            color: 'var(--mui-palette-text-primary)',
           }}
           aria-label="Close panel"
         >


### PR DESCRIPTION
## Summary

Fixes white drawer background in dark mode by using the correct MUI CSS variable.

## Changes

- Changed drawer `backgroundColor` from `var(--mui-palette-background-paper)` to `var(--mui-palette-background-default)`
- Removed unnecessary fallback values that were preventing theme variables from resolving correctly
- Cleaned up other inline styles to use simpler CSS variable references

## Testing

Build succeeds ✅

The drawer should now properly adapt to dark mode with the same background color as the rest of the Headlamp UI.

🤖 Generated with [Claude Code](https://claude.ai/code)