### PR TITLE
fix: use background-paper for drawer to match Headlamp standard

### DIFF
--- a/src/components/NamespacesListView.tsx
+++ b/src/components/NamespacesListView.tsx
@@ -103,7 +103,7 @@ function NamespaceDetailPanel({ namespace, onClose }: NamespaceDetailPanelProps)
         top: 0,
         bottom: 0,
         width: '1000px',
-        backgroundColor: 'var(--mui-palette-background-default)',
+        backgroundColor: 'var(--mui-palette-background-paper)',
         color: 'var(--mui-palette-text-primary)',
         boxShadow: '-2px 0 8px rgba(0,0,0,0.15)',
         overflowY: 'auto',


### PR DESCRIPTION
## Summary

Fixes drawer background to use the correct MUI CSS variable for elevated surfaces.

## Changes

- Changed drawer `backgroundColor` from `var(--mui-palette-background-default)` to `var(--mui-palette-background-paper)`
- `background-paper` is the standard MUI variable for elevated surfaces (drawers, dialogs, cards)
- `background-default` is for the main page background, not elevated components

## Why

The drawer should have an opaque elevated surface background that matches Headlamp's standard drawer/dialog style, not a transparent or page-level background.

## Testing

Build succeeds ✅

The drawer should now have the proper opaque background matching Headlamp's standard UI patterns.

🤖 Generated with [Claude Code](https://claude.ai/code)