### PR TITLE
fix: change plugin display name to 'polaris'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "headlamp-polaris-plugin",
+  "name": "polaris",
   "version": "0.3.5",
   "description": "Headlamp plugin for Fairwinds Polaris audit results",
   "scripts": {


### PR DESCRIPTION
Simplifies the plugin name shown in Headlamp Settings → Plugins.

## Changes

**Before:** `headlamp-polaris-plugin`
**After:** `polaris`

## Screenshot

![Before](https://github.com/user-attachments/assets/...)

The plugin will now show as "polaris" in the Settings → Plugins list for cleaner UI presentation.

## Testing

- Build plugin: `npm run build`
- Package: `npm run package`
- Install in Headlamp
- Verify Settings → Plugins shows "polaris"

🤖 Generated with [Claude Code](https://claude.com/claude-code)