### PR TITLE
ci: use on-prem runners for E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: k3s-animaniacs
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Problem

E2E tests are failing on all branches with DNS resolution errors:

```
Error: page.goto: net::ERR_NAME_NOT_RESOLVED at https://headlamp.animaniacs.farh.net/
```

**Root cause:** GitHub-hosted runners don't have network access to `headlamp.animaniacs.farh.net` (private network).

## Solution

Use self-hosted ARC (Actions Runner Controller) runners that run in the same network as the Headlamp instance.

### Changes

**Before:**
```yaml
jobs:
  e2e:
    runs-on: ubuntu-latest
```

**After:**
```yaml
jobs:
  e2e:
    runs-on: k3s-animaniacs
```

### Runner Configuration

Self-hosted runners configured via Flux:
- **Runner scale set:** `k3s-animaniacs`
- **Config:** `kubernetes/base/arc-runners/helmrelease-arc-runner-set.yaml`
- **GitHub App auth:** Configured for `cpfarhood/kubernetes` org
- **Capacity:** 0-4 runners (scale to zero when idle)
- **Container mode:** Docker-in-Docker (dind)

## Impact

✅ **E2E tests work** - Runners have network access to `headlamp.animaniacs.farh.net`
✅ **PRs properly validated** - E2E tests run on push/PR as intended
✅ **Cost savings** - Self-hosted runners (no GitHub Actions minutes consumed)
✅ **Auto-scaling** - Runners scale from 0 to 4 based on demand

## Testing

E2E tests will now run:
1. **On push to main**
2. **On pull requests**
3. **Manual workflow_dispatch**

Tests use self-hosted runners with access to:
- Headlamp instance: `https://headlamp.animaniacs.farh.net`
- Authentik OIDC provider for authentication

## Alternatives Considered

1. ❌ **Expose Headlamp publicly** - Security concern
2. ❌ **Disable E2E on CI** - Loses automated testing
3. ✅ **Use on-prem runners** - Best of both worlds

## References

- ARC runner config: `kubernetes/base/arc-runners/helmrelease-arc-runner-set.yaml`
- Failed E2E run (GitHub-hosted): https://github.com/cpfarhood/headlamp-polaris-plugin/actions/runs/21946461082
- Error: `ERR_NAME_NOT_RESOLVED` at authentication step

🤖 Generated with [Claude Code](https://claude.com/claude-code)