### PR TITLE
feat: add repository metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,16 @@
   "name": "polaris",
   "version": "0.3.5",
   "description": "Headlamp plugin for Fairwinds Polaris audit results",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cpfarhood/headlamp-polaris-plugin.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cpfarhood/headlamp-polaris-plugin/issues"
+  },
+  "homepage": "https://github.com/cpfarhood/headlamp-polaris-plugin#readme",
+  "author": "cpfarhood",
+  "license": "Apache-2.0",
   "scripts": {
     "start": "headlamp-plugin start",
     "build": "headlamp-plugin build",


### PR DESCRIPTION
## Summary
Add repository metadata fields to `package.json` to enable GitHub repository link in Headlamp plugin UI.

## Changes
- Added `repository` field with Git URL
- Added `bugs` field for issue tracking
- Added `homepage` field for project homepage
- Added `author` field
- Added `license` field (Apache-2.0)

## Benefits
- Enables clickable GitHub link in Headlamp's plugin settings Origin column
- Improves discoverability and metadata for plugin users
- Aligns with best practices for npm packages

## Testing
After merging and republishing, the plugin will show a GitHub link in Headlamp's Plugins settings page.

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)