### PR TITLE
fix: ensure namespace detail drawer has no transparency

### DIFF
--- a/src/components/NamespacesListView.tsx
+++ b/src/components/NamespacesListView.tsx
@@ -109,6 +109,7 @@ function NamespaceDetailPanel({ namespace, onClose }: NamespaceDetailPanelProps)
         overflowY: 'auto',
         zIndex: 1200,
         padding: '20px',
+        opacity: 1,
       }}
     >
       <div


### PR DESCRIPTION
## Problem

Namespace detail drawer may show transparency in certain theme conditions.

## Solution

Add explicit `opacity: 1` to drawer panel styles to ensure it's completely opaque in both light and dark modes.

### Changes

**Before:**
```tsx
style={{
  position: 'fixed',
  // ...
  backgroundColor: 'var(--mui-palette-background-paper)',
  // ...
}}
```

**After:**
```tsx
style={{
  position: 'fixed',
  // ...
  backgroundColor: 'var(--mui-palette-background-paper)',
  // ...
  opacity: 1,
}}
```

## Testing

1. Build plugin: `npm run build`
2. Install in Headlamp
3. Navigate to Polaris → Namespaces
4. Click a namespace to open detail drawer
5. Verify drawer background is fully opaque in both light and dark modes

## Related

- PR #7: Fixed drawer to use `background-paper` variable
- PR #6: Added dark mode support

🤖 Generated with [Claude Code](https://claude.com/claude-code)